### PR TITLE
Address  #11 with a larger number

### DIFF
--- a/src/main/java/burp/j2ee/issues/impl/ELInjection.java
+++ b/src/main/java/burp/j2ee/issues/impl/ELInjection.java
@@ -57,8 +57,8 @@ public class ELInjection implements IModule {
         // Execute a basic algorithm operation to detect OGNL code execution
         int MAX_RANDOM_INT = 500;
         Random rand = new Random();
-        final int firstInt = rand.nextInt(MAX_RANDOM_INT) + 2;
-        final int secondInt = rand.nextInt(MAX_RANDOM_INT) + 2;
+        final int firstInt = rand.nextInt(MAX_RANDOM_INT) + 42 + 42 + rand.nextInt(MAX_RANDOM_INT);
+        final int secondInt = rand.nextInt(MAX_RANDOM_INT) + 42 + 42 + rand.nextInt(MAX_RANDOM_INT);
         final String multiplication = Integer.toString(firstInt * secondInt);
 
         byte[] EL_TEST = "(new+java.util.Scanner((T(java.lang.Runtime).getRuntime().exec(\"cat+/etc/passwd\").getInputStream()),\"UTF-8\")).useDelimiter(\"\\\\A\").next()".getBytes();


### PR DESCRIPTION
This patch should minimize the number of false positives for EL injection.

It uses a minimum number for each factor and instead of one two random numbers each so that under really worst conditions one factor is around 100 and the other higher. That should suffice for 99,9999% of all cases (educated guess).