### PR TITLE
fix: bump sqlite-jdbc version to support mac aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,15 +20,15 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.16.1</version>
+            <version>3.40.0.0</version>
         </dependency>
-    
+
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -64,7 +64,7 @@
             <type>jar</type>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -81,8 +81,8 @@
                         </manifest>
                     </archive>
                 </configuration>
-                
-                     
+
+
                 <executions>
                     <execution>
                         <id>make-assembly</id>
@@ -96,7 +96,7 @@
         </plugins>
     </build>
 
-        
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>


### PR DESCRIPTION
In new version sqlite-jdbc adds a native library for mac on m1

Issue for reference: https://github.com/xerial/sqlite-jdbc/issues/562