### PR TITLE
Update JKStatus.java to bypass restrictions

### DIFF
--- a/src/main/java/burp/j2ee/issues/impl/JKStatus.java
+++ b/src/main/java/burp/j2ee/issues/impl/JKStatus.java
@@ -55,6 +55,15 @@ public class JKStatus implements IModule{
             "/jkmanager",
             "/jkmanager-auth",
             "/jdkstatus"
+        
+        // Restriction Bypass using a semi-colon
+            "/jk-status;",
+            "/jkstatus-auth;",
+            "/jkstatus;",
+            "/jkmanager;",
+            "/jkmanager-auth;",
+            "/jdkstatus;"
+        
     );   
 
     private static final byte[] GREP_STRING = "JK Status Manager".getBytes();


### PR DESCRIPTION
For vulnerable targets, I have observed J2EEScan in Burpsuite does not detect JK endpoints with forbidden or restricted access. Appending a semi-colon at those endpoints will result in a bypass and should likely be detected by the scanner. Reference: https://www.immunit.ch/en/blog/2018/11/02/cve-2018-11759-apache-mod_jk-access-control-bypass/