### PR TITLE
Fix: jolokia detection

### DIFF
--- a/src/main/java/burp/j2ee/issues/impl/SpringBootActuator.java
+++ b/src/main/java/burp/j2ee/issues/impl/SpringBootActuator.java
@@ -66,7 +66,8 @@ public class SpringBootActuator implements IModule {
             "{\"status\":\"UP\"}".getBytes(),
             "{\"_links\":".getBytes(),
             "org.spring".getBytes(),
-            "java.vendor".getBytes()
+            "java.vendor".getBytes(),
+            "\"class\":\"org.jolokia.backend.Config\"".getBytes()
     );
         
     


### PR DESCRIPTION
Hi,

currently jolokia installations are not correctly detected, as none of the included strings match the tested `/jolokia/list` endpoint.
This pull request adds a generic string, which is typically contained in the `/jolokia/list` endpoint.
